### PR TITLE
chore: changed loadbalancer to clusterip

### DIFF
--- a/kubernetes/history-svc-service.yaml
+++ b/kubernetes/history-svc-service.yaml
@@ -8,11 +8,10 @@ metadata:
     io.kompose.service: history-svc
   name: history-svc
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - protocol: TCP
       port: 3005
       targetPort: 3005
-      nodePort: 30005
   selector:
     io.kompose.service: history-svc


### PR DESCRIPTION
This pull request includes a change to the `kubernetes/history-svc-service.yaml` file to modify the service type from `LoadBalancer` to `ClusterIP`.

Network configuration update:

* [`kubernetes/history-svc-service.yaml`](diffhunk://#diff-395daea2d9f2e2e0b1f5d971da68eaf6215c2f3c2167614cde017c1863a5e660L11-L16): Changed the service type from `LoadBalancer` to `ClusterIP` to adjust the network exposure of the `history-svc` service.